### PR TITLE
Check if ::RSpec has a method named configuration

### DIFF
--- a/lib/stimpack/integrations/rspec.rb
+++ b/lib/stimpack/integrations/rspec.rb
@@ -3,6 +3,7 @@ module Stimpack
     class RSpec
       def self.install(app)
         return unless defined?(::RSpec)
+        return unless ::RSpec.respond_to?(:configuration)
 
         Packs.each do |pack|
           ::RSpec.configuration.pattern.concat(",#{pack.relative_path.join("spec/**/*_spec.rb")}")


### PR DESCRIPTION
Instead of only checking the `::RSpec` module, also verify we have a method named `configuration` to use.