### PR TITLE
Add functionality for nested packs

### DIFF
--- a/lib/stimpack/packs.rb
+++ b/lib/stimpack/packs.rb
@@ -12,8 +12,9 @@ module Stimpack
       end
 
       def resolve
-        # Gather all the packs under the root directory and create packs.
-        root.children.select(&:directory?).sort!.each do |path|
+        # Gather all the parent packs and the children packs.
+        package_locations = root.glob('*/{package.yml,*/package.yml}').map(&:dirname)
+        package_locations.sort!.each do |path|
           next unless pack = Pack.create(path)
           @packs[pack.name] = pack
         end

--- a/lib/stimpack/railtie.rb
+++ b/lib/stimpack/railtie.rb
@@ -4,6 +4,8 @@ module Stimpack
   class Railtie < Rails::Railtie
     config.before_configuration do |app|
       Stimpack.load(app)
+      # This is not used within stimpack. Rather, this allows OTHER tools to
+      # hook into Stimpack via ActiveSupport hooks.
       ActiveSupport.run_load_hooks(:stimpack, Packs)
     end
   end

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,3 +1,3 @@
 module Stimpack
-  VERSION = "0.5.0".freeze
+  VERSION = "0.6.0".freeze
 end

--- a/spec/fixtures/rails-7.0/packs/pants/shorts/app/models/shorts/zipper.rb
+++ b/spec/fixtures/rails-7.0/packs/pants/shorts/app/models/shorts/zipper.rb
@@ -1,0 +1,4 @@
+module Shorts
+  class Zipper
+  end
+end

--- a/spec/fixtures/rails-7.0/packs/pants/shorts/app/services/shorts/khaki.rb
+++ b/spec/fixtures/rails-7.0/packs/pants/shorts/app/services/shorts/khaki.rb
@@ -1,0 +1,4 @@
+module Shorts
+  class Khaki
+  end
+end

--- a/spec/fixtures/rails-7.0/packs/pants/shorts/app/services/shorts/linen.rb
+++ b/spec/fixtures/rails-7.0/packs/pants/shorts/app/services/shorts/linen.rb
@@ -1,0 +1,4 @@
+module Shorts
+  class Linen
+  end
+end

--- a/spec/stimpack_spec.rb
+++ b/spec/stimpack_spec.rb
@@ -17,4 +17,16 @@ RSpec.describe Stimpack do
   it "creates engines namespace for engine packs" do
     expect(defined?(Shoes::Engine)).to eq("constant")
   end
+
+  context 'nested packs' do
+    it "autoloads classes in autoload paths" do
+      expect(defined?(Shorts::Linen)).to eq("constant")
+    end
+
+    it "adds pack paths to the application" do
+      Stimpack.config.paths.each do |path|
+        expect(Rails.application.paths[path].paths).to include(rails_dir.join(Stimpack.config.root, "pants", "shorts", path))
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,0 @@
-require "minitest/autorun"
-require_relative "../lib/stimpack"


### PR DESCRIPTION
# Summary

This PR allows stimpack to support one-level-deep nested packs.

# Commits
- Remove minitest
- add clarifying comment
- Add new tests and functionality
- Bump verson
