### PR TITLE
Search file in packs beginning with nested packs

### DIFF
--- a/lib/stimpack/packs.rb
+++ b/lib/stimpack/packs.rb
@@ -24,7 +24,7 @@ module Stimpack
       def find(path)
         path = "#{path}/"
 
-        @packs.values.find do |pack|
+        @packs.values.reverse.find do |pack|
           path.start_with?("#{pack.path}/")
         end
       end

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,3 +1,3 @@
 module Stimpack
-  VERSION = "0.6.0".freeze
+  VERSION = "0.6.1".freeze
 end


### PR DESCRIPTION
Now that Stimpack supports nested packs :partying_face:, I came across a detail that caused an error when searching for a file that was inside a nested pack.
Imagine this scenario
```
app/
  - cells/
config/
...
packs/
  - base_pack/ --- This is a pack
    - app/
      - cells/
      - controllers/
      - models/
      - ...
    - config
    - nested_pack/ --- This is another pack
      - app/
        - cells/
          - test_cell.rb
        - controllers
        - models/
    - other_nested_pack/ -- This is another pack
      - app/
        - cells/
          - test_cell.rb
```
In order to make the [Cells](https://github.com/trailblazer/cells) work, we had to add a function that finds the pack where the cell is stored by using the `.find` method in `Stimpack::Packs`

When this function searched for the `test_cell.rb` this is what was going on:
```ruby
file = '~project/packs/base_pack/nested_pack/app/cells/test_cell.rb'
pack = Stimpack::Packs.find(file)
```

The orded in which this method searches for the file will be the next one:

1. packs/base_pack
2. packs/base_pack/nested_pack
3. packs/base_pack/other_nested_pack

All the packs paths here begin with 'packs/base_pack', so the `find` method will return the first, even if the file is not there.
I suggest the following order:

1. packs/base_pack/other_nested_pack
2. packs/base_pack/nested_pack
3. packs/base_pack

This will cause the `find` method to fail on the first path, but succeed on the second which is expected. If a file belongs to the last pack, then it will find it since the path will be different from the others

PS: This is my first time contributing in an open source project, any feedback is welcome and encouraged :smile: 