### PR TITLE
Refactor internals and improve RSpec support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ metadata:
   engine: true
 ```
 
+### RSpec Integration
+It's highly recommended that you add `--require stimpack/rspec` to your `.rspec` file to keep things simply.
+Or, if you'd like, pass it as an argument to `rspec`:
+
+```
+$ rspec --require stimpack/rspec ...
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Gusto/stimpack.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ metadata:
 ```
 
 ### RSpec Integration
-It's highly recommended that you add `--require stimpack/rspec` to your `.rspec` file to keep things simply.
+Simply add `--require stimpack/rspec` to your `.rspec`.
 Or, if you'd like, pass it as an argument to `rspec`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ Or, if you'd like, pass it as an argument to `rspec`:
 $ rspec --require stimpack/rspec ...
 ```
 
+Integration will allow you to run tests as such:
+```
+# Run all specs in your entire application (packs and all):
+rspec
+
+# Run just that one test:
+rspec spec/some/specific_spec.rb
+
+# Run all tests under the "foobar" pack and all the tests of its nested packs:
+rspec packs/foobar
+
+# Same as above but also adds the "binbaz" pack:
+rspec packs/foobar pack/binbaz
+
+# Run all test files inside the "packs/foobar/spec" directory:
+rspec packs/foobar/spec
+
+# Run all specs under the "packs/foobar/nested_pack" pack:
+rspec packs/foobar/nested_pack
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Gusto/stimpack.

--- a/lib/stimpack.rb
+++ b/lib/stimpack.rb
@@ -1,4 +1,5 @@
 require "active_support"
+require "rails/application"
 
 module Stimpack
   extend ActiveSupport::Autoload
@@ -14,16 +15,12 @@ module Stimpack
   class << self
     attr_reader :config
 
-    def load(app)
-      Packs.resolve
-
-      Integrations::Rails.install(app)
-      Integrations::FactoryBot.install(app)
-      Integrations::RSpec.install(app)
+    def packs_root
+      @root ||= app_root.join(config.root)
     end
 
-    def [](name)
-      Packs[name.to_s]
+    def app_root
+      @app_root ||= Rails::Application.find_root(Dir.pwd)
     end
   end
 
@@ -44,6 +41,8 @@ module Stimpack
     config/initializers
     config/routes
   )
+  # (0) / -> (1) /packs -> (2) /packs/foo/bar
+  @config.max_levels = 2
 end
 
 require "stimpack/railtie"

--- a/lib/stimpack.rb
+++ b/lib/stimpack.rb
@@ -15,12 +15,8 @@ module Stimpack
   class << self
     attr_reader :config
 
-    def packs_root
-      @root ||= app_root.join(config.root)
-    end
-
-    def app_root
-      @app_root ||= Rails::Application.find_root(Dir.pwd)
+    def root
+      @root ||= Rails::Application.find_root(Dir.pwd)
     end
   end
 
@@ -41,8 +37,6 @@ module Stimpack
     config/initializers
     config/routes
   )
-  # (0) / -> (1) /packs -> (2) /packs/foo/bar
-  @config.max_levels = 2
 end
 
 require "stimpack/railtie"

--- a/lib/stimpack/integrations/factory_bot.rb
+++ b/lib/stimpack/integrations/factory_bot.rb
@@ -1,10 +1,10 @@
 module Stimpack
   module Integrations
     class FactoryBot
-      def self.install(app)
+      def initialize(app)
         return unless app.config.respond_to?(:factory_bot)
 
-        Packs.each do |pack|
+        Packs.all.each do |pack|
           app.config.factory_bot.definition_file_paths << pack.relative_path.join("spec/factories").to_s
         end
       end

--- a/lib/stimpack/integrations/rails.rb
+++ b/lib/stimpack/integrations/rails.rb
@@ -1,16 +1,52 @@
 # frozen_string_literal: true
 
+require "active_support/inflections"
+
 module Stimpack
   module Integrations
     class Rails
-      def self.install(app)
-        Stimpack.config.paths.freeze
+      def initialize(app)
+        @app = app
 
-        Packs.each do |pack|
+        Stimpack.config.paths.freeze
+        create_engines
+        inject_paths
+      end
+
+      def create_engines
+        Packs.all.each do |pack|
+          next unless pack.config.engine?
+
+          pack.engine = create_engine(pack)
+        end
+      end
+
+      def inject_paths
+        Packs.all.each do |pack|
           Stimpack.config.paths.each do |path|
-            app.paths[path] << pack.path.join(path)
+            @app.paths[path] << pack.path.join(path)
           end
         end
+      end
+
+      private
+
+      def create_namespace(name)
+        namespace = ActiveSupport::Inflector.camelize(name)
+        namespace.split("::").reduce(Object) do |base, mod|
+          if base.const_defined?(mod, false)
+            base.const_get(mod, false)
+          else
+            base.const_set(mod, Module.new)
+          end
+        end
+      end
+
+      def create_engine(pack)
+        name = pack.path.relative_path_from(Stimpack.packs_root)
+        namespace = create_namespace(pack.name)
+        stim = Stim.new(pack, namespace)
+        namespace.const_set("Engine", Class.new(::Rails::Engine)).include(stim)
       end
     end
   end

--- a/lib/stimpack/integrations/rails.rb
+++ b/lib/stimpack/integrations/rails.rb
@@ -43,7 +43,7 @@ module Stimpack
       end
 
       def create_engine(pack)
-        name = pack.path.relative_path_from(Stimpack.packs_root)
+        name = pack.path.relative_path_from(Stimpack::Packs.root)
         namespace = create_namespace(pack.name)
         stim = Stim.new(pack, namespace)
         namespace.const_set("Engine", Class.new(::Rails::Engine)).include(stim)

--- a/lib/stimpack/integrations/rspec.rb
+++ b/lib/stimpack/integrations/rspec.rb
@@ -29,7 +29,7 @@ module Stimpack
             if pack = Packs.all_by_path[path]
               [
                 pack,
-                *pack.all_children
+                *Packs.all(pack)
               ].map do |pack|
                 spec_path = pack.relative_path.join(default_path)
                 spec_path.to_s if spec_path.exist?

--- a/lib/stimpack/integrations/rspec.rb
+++ b/lib/stimpack/integrations/rspec.rb
@@ -1,19 +1,46 @@
 module Stimpack
   module Integrations
     class RSpec
-      def self.install(app)
-        return unless defined?(::RSpec)
-        # Sometimes, the `rspec-rails` gem is installed in the development
-        # group. This means the ::RSpec module will be defined. However, this
-        # doesn't mean that we've loaded rspec-core, or even about to run tests.
-        # Let's make sure we are actually loading the test environment before
-        # installing our integration. An easy of doing this is seeing of the
-        # configuration method exists on RSpec.
-        return unless ::RSpec.respond_to?(:configuration)
+      def initialize
+        # This is the list of directories RSpec was told to run.
+        to_run = ::RSpec.configuration.instance_variable_get(:@files_or_directories_to_run)
+        default_path = ::RSpec.configuration.default_path
 
-        Packs.each do |pack|
-          ::RSpec.configuration.pattern.concat(",#{pack.relative_path.join("spec/**/*_spec.rb")}")
+        if to_run == [default_path]
+          # This is the default case when you run `rspec`. We want to add all the pack's spec paths
+          # to the collection of directories to run.
+
+          pack_paths = Packs.all.map do |pack|
+            spec_path = pack.relative_path.join(default_path)
+            spec_path.to_s if spec_path.exist?
+          end
+
+          to_run.concat(pack_paths)
+        else
+          # This is when `rspec` is run with a list of directories or files. We scan this list to see
+          # if any of them matches a pack's directory. If it does, we concat the `default_path` to the
+          # end of it.
+          #
+          # packs/my_pack => packs/my_pack/spec
+          # 
+          # If it doesn't match a pack path, we leave it alone.
+
+          to_run.map! do |path|
+            if pack = Packs.all_by_path[path]
+              [
+                pack,
+                *pack.all_children
+              ].map do |pack|
+                spec_path = pack.relative_path.join(default_path)
+                spec_path.to_s if spec_path.exist?
+              end
+            else
+              path
+            end
+          end
         end
+
+        ::RSpec.configuration.files_or_directories_to_run = to_run.flatten.compact.uniq
       end
     end
   end

--- a/lib/stimpack/pack.rb
+++ b/lib/stimpack/pack.rb
@@ -1,53 +1,55 @@
 # frozen_string_literal: true
 
+require "pathname"
+
 module Stimpack
   class Pack
     PACKAGE_FILE = "package.yml"
+    ROOT_PATH = Pathname.new(".")
 
     autoload :Configuration, "stimpack/pack/configuration"
 
-    attr_reader :name
     attr_reader :path
-    attr_reader :engine
+    attr_reader :name
+    attr_accessor :engine
 
-    def self.create(path)
-      new(path) if path.join(PACKAGE_FILE).exist?
+    def initialize(path, level:, packs_path: nil)
+      if Stimpack.config.max_levels && level > Stimpack.config.max_levels
+        raise ArgumentError, "level (#{level}) exceeds max_levels (#{Stimpack.config.max_levels})"
+      elsif !path.join(PACKAGE_FILE).exist?
+        raise ArgumentError, "path does not contain a #{PACKAGE_FILE} file: #{path}"
+      end
+
+      @path = path
+      @name = path.basename
+      @level = level
+      @packs_path = packs_path
     end
 
-    def initialize(path)
-      @path = path
-      @name = path.relative_path_from(Packs.root)
-
-      if config.engine?
-        @engine = create_engine
+    def children
+      @children ||= begin
+        pack_paths = @packs_path&.glob("*/#{PACKAGE_FILE}") || []
+        packs = pack_paths.map(&:dirname).sort.map do |pack_path|
+          Pack.new(pack_path, level: @level + 1, packs_path: pack_path)
+        end
+        packs.freeze
       end
     end
 
+    def all_children
+      @all_children ||= (children + children.map(&:all_children).flatten).freeze
+    end
+
+    def root?
+      path == Stimpack.app_root
+    end
+
     def relative_path
-      @relative_path ||= path.relative_path_from(Rails.root)
+      @relative_path ||= path.relative_path_from(Stimpack.app_root)
     end
 
     def config
       @config ||= Configuration.new(path.join(PACKAGE_FILE))
-    end
-
-    private
-
-    def create_engine
-      namespace = create_namespace(name)
-      stim = Stim.new(self, namespace)
-      namespace.const_set("Engine", Class.new(Rails::Engine)).include(stim)
-    end
-
-    def create_namespace(name)
-      namespace = ActiveSupport::Inflector.camelize(name)
-      namespace.split("::").reduce(Object) do |base, mod|
-        if base.const_defined?(mod)
-          base.const_get(mod)
-        else
-          base.const_set(mod, Module.new)
-        end
-      end
     end
   end
 end

--- a/lib/stimpack/pack.rb
+++ b/lib/stimpack/pack.rb
@@ -14,7 +14,7 @@ module Stimpack
 
     def initialize(path)
       @path = path
-      @name = path.basename
+      @name = path.basename.to_s
     end
 
     def relative_path

--- a/lib/stimpack/pack.rb
+++ b/lib/stimpack/pack.rb
@@ -5,7 +5,6 @@ require "pathname"
 module Stimpack
   class Pack
     PACKAGE_FILE = "package.yml"
-    ROOT_PATH = Pathname.new(".")
 
     autoload :Configuration, "stimpack/pack/configuration"
 
@@ -13,39 +12,13 @@ module Stimpack
     attr_reader :name
     attr_accessor :engine
 
-    def initialize(path, level:, packs_path: nil)
-      if Stimpack.config.max_levels && level > Stimpack.config.max_levels
-        raise ArgumentError, "level (#{level}) exceeds max_levels (#{Stimpack.config.max_levels})"
-      elsif !path.join(PACKAGE_FILE).exist?
-        raise ArgumentError, "path does not contain a #{PACKAGE_FILE} file: #{path}"
-      end
-
+    def initialize(path)
       @path = path
       @name = path.basename
-      @level = level
-      @packs_path = packs_path
-    end
-
-    def children
-      @children ||= begin
-        pack_paths = @packs_path&.glob("*/#{PACKAGE_FILE}") || []
-        packs = pack_paths.map(&:dirname).sort.map do |pack_path|
-          Pack.new(pack_path, level: @level + 1, packs_path: pack_path)
-        end
-        packs.freeze
-      end
-    end
-
-    def all_children
-      @all_children ||= (children + children.map(&:all_children).flatten).freeze
-    end
-
-    def root?
-      path == Stimpack.app_root
     end
 
     def relative_path
-      @relative_path ||= path.relative_path_from(Stimpack.app_root)
+      @relative_path ||= path.relative_path_from(Stimpack.root)
     end
 
     def config

--- a/lib/stimpack/packs.rb
+++ b/lib/stimpack/packs.rb
@@ -1,43 +1,23 @@
 # frozen_string_literal: true
 
 require "active_support"
-require "pathname"
-require "rails"
 
 module Stimpack
   module Packs
     class << self
       def root
-        @root ||= Rails.root.join(Stimpack.config.root)
+        @root ||= Pack.new(Stimpack.app_root, level: 0, packs_path: Stimpack.packs_root)
       end
 
-      def resolve
-        # Gather all the parent packs and the children packs.
-        package_locations = root.glob('*/{package.yml,*/package.yml}').map(&:dirname)
-        package_locations.sort!.each do |path|
-          next unless pack = Pack.create(path)
-          @packs[pack.name] = pack
+      def all
+        @all ||= root.all_children.sort_by(&:relative_path)
+      end
+
+      def all_by_path
+        @all_by_path ||= all.each_with_object({}) do |pack, map|
+          map[pack.relative_path.to_s] = pack
         end
-        @packs.freeze
-      end
-
-      def find(path)
-        path = "#{path}/"
-
-        @packs.values.reverse.find do |pack|
-          path.start_with?("#{pack.path}/")
-        end
-      end
-
-      def [](name)
-        @packs[name]
-      end
-
-      def each(*args, &block)
-        @packs.each_value(*args, &block)
       end
     end
-
-    @packs = {}
   end
 end

--- a/lib/stimpack/packs.rb
+++ b/lib/stimpack/packs.rb
@@ -9,6 +9,14 @@ module Stimpack
         @root ||= Pack.new(Stimpack.app_root, level: 0, packs_path: Stimpack.packs_root)
       end
 
+      def find(path)
+        @find_pack_paths ||= all_by_path.keys.sort_by(&:length).reverse!.map { |path| "#{path}/" }
+        path = "#{path}/"
+        @find_pack_paths.find do |pack_path|
+          path.start_with?(pack_path)
+        end
+      end
+
       def all
         @all ||= root.all_children.sort_by(&:relative_path)
       end

--- a/lib/stimpack/packs.rb
+++ b/lib/stimpack/packs.rb
@@ -4,9 +4,11 @@ require "active_support"
 
 module Stimpack
   module Packs
+    PACKAGE_GLOB_PATTERN = "*/#{Pack::PACKAGE_FILE}"
+
     class << self
       def root
-        @root ||= Pack.new(Stimpack.app_root, level: 0, packs_path: Stimpack.packs_root)
+        @root ||= Stimpack.root.join(Stimpack.config.root)
       end
 
       def find(path)
@@ -17,14 +19,28 @@ module Stimpack
         end
       end
 
-      def all
-        @all ||= root.all_children.sort_by(&:relative_path)
+      def all(parent = nil)
+        @all ||= resolve(root).each_with_object({}) do |pack, map|
+          map[pack] = resolve(pack.path).freeze
+        end.freeze
+
+        if parent
+          @all[parent]
+        else
+          @all.keys + @all.values.flatten
+        end
       end
 
       def all_by_path
         @all_by_path ||= all.each_with_object({}) do |pack, map|
           map[pack.relative_path.to_s] = pack
         end
+      end
+
+      private
+
+      def resolve(directory)
+        directory.glob(PACKAGE_GLOB_PATTERN).map { |path| Pack.new(path.dirname) }
       end
     end
   end

--- a/lib/stimpack/railtie.rb
+++ b/lib/stimpack/railtie.rb
@@ -1,9 +1,11 @@
-require "rails"
+require "rails/railtie"
 
 module Stimpack
   class Railtie < Rails::Railtie
     config.before_configuration do |app|
-      Stimpack.load(app)
+      Integrations::Rails.new(app)
+      Integrations::FactoryBot.new(app)
+
       # This is not used within stimpack. Rather, this allows OTHER tools to
       # hook into Stimpack via ActiveSupport hooks.
       ActiveSupport.run_load_hooks(:stimpack, Packs)

--- a/lib/stimpack/rspec.rb
+++ b/lib/stimpack/rspec.rb
@@ -1,0 +1,3 @@
+require "stimpack"
+
+Stimpack::Integrations::RSpec.new

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,3 +1,3 @@
 module Stimpack
-  VERSION = "0.6.1".freeze
+  VERSION = "0.7.0".freeze
 end

--- a/spec/stimpack_spec.rb
+++ b/spec/stimpack_spec.rb
@@ -1,6 +1,7 @@
 require "pathname"
 
 rails_dir = Pathname.new(File.expand_path("fixtures/rails-7.0", __dir__))
+Dir.chdir(rails_dir)
 require_relative rails_dir.join("config/environment")
 
 RSpec.describe Stimpack do


### PR DESCRIPTION
This PR refactors Stimpack and breaks the initialization step into 2 process: non-Rails and Rails. The non-rails part simply provides packs and pack traversal. When Rails is involved, we inject the packs into Rails (along with Engine support). This helps us extract the RSpec helper so that it works without Rails booting.

Fixes #15

For better RSpec support, you now have to `--require stimpack/rspec`. You can add this to `.rspec` or add it to your command line: `bundle exec rspec --require stimpack/rspec ...`

This allows Stimpack to hook into RSpec before files are resolved. Because of this, we're now able to do some fancy stuff:

(This assumes you've added `--require stimpack/rspec` to `.rspec`)
```
bundle exec rspec #=> Runs _all_ specs in your entire application (packs and all)
bundle exec rspec spec/some/specific_spec.rb #=> Runs just that one test
bundle exec rspec packs/foobar #=> Runs all specs under the foobar pack _and_ all the specs of its nested packs
bundle exec rspec packs/foobar pack/binbaz #=> same as above but also adds the binbaz pack
bundle exec rspec packs/foobar/spec #=> Runs all spec files inside the "packs/foobar/spec" directory
bundle exec rspec packs/foobar/nested_pack #=> Runs all specs under the "packs/foobar/nested_pack" pack
```