### PR TITLE
Feature enhancement to support Zeitwerk custom root namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,52 @@ metadata:
   engine: true
 ```
 
+### Making your package use a single namespace
+If you want to use a single namespace for all classes in your package, you can have Stimpack help by patching Zeitwerk so that the namespace subdirectories aren't necessary.
+Enable this feature like this
+```yml
+# packs/my_pack/package.yml
+enforce_dependencies: true
+enforce_privacy: true
+metadata:
+  automatic_pack_namespace: true
+```
+
+and turn this
+
+```
+products
+├── app
+│   ├── models
+│   │   └── products
+│   │       ├── package_record.rb              # Products::PackageRecord
+│   │       ├── product.rb                     # Products::Product
+│   │       └── sku.rb                         # Products::SKU
+│   ├── public
+│   │   ├── products
+│   │   │   ├── product_mediums.rb       # Products::ProductMediums
+│   │   │   └── products_operations.rb   # Products::ProductOperations
+│   │   └── products.rb
+│   └── services
+│       └── products
+```
+into this:
+
+```
+products
+├── app
+│   ├── models
+│   │  ├── package_record.rb         # Products::PackageRecord
+│   │  ├── product.rb                # Products::Product
+│   │  └── sku.rb                    # Products::SKU
+│   ├── public
+│   │   ├── product_mediums.rb       # Products::ProductMediums
+│   │   │── products_operations.rb   # Products::ProductOperations
+│   │   └── products.rb
+│   └── services
+
+```
+
 ## Ecosystem and Integrations
 
 ### RSpec Integration

--- a/README.md
+++ b/README.md
@@ -138,9 +138,19 @@ products
 
 ```
 
-Note one shortcoming with this approach is that the root namespace module definition will not be reloadable with this option enabled for the pack. 
-That is, you will need to restart your running server to see changes to `Products` itself. So, when you add `Products.operation1`, you'll need to
-restart your server for it to be recognized. 
+Note one shortcoming with this approach is that the root namespace module definition can not be customized, for example,
+as the organizer of your public API. Thus, the (not uncommon) pattern of accessing `Products.public_operation1` defined
+like this:
+
+```
+# packs/products/public/product.rb
+module Products
+  def public_operation1
+  end
+end
+```
+
+is not supported.
 
 ## Ecosystem and Integrations
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ products
 
 ```
 
+Note one shortcoming with this approach is that the root namespace module definition will not be reloadable with this option enabled for the pack. 
+That is, you will need to restart your running server to see changes to `Products` itself. So, when you add `Products.operation1`, you'll need to
+restart your server for it to be recognized. 
+
 ## Ecosystem and Integrations
 
 ### RSpec Integration

--- a/lib/stimpack/integrations/rails.rb
+++ b/lib/stimpack/integrations/rails.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require "active_support/inflections"
+require 'pry'
 
 module Stimpack
   module Integrations
     class Rails
       def initialize(app)
         @app = app
-
+        ::Rails.autoloaders.main.log!
         Stimpack.config.paths.freeze
         create_engines
         inject_paths
@@ -23,8 +24,11 @@ module Stimpack
 
       def inject_paths
         Packs.all.each do |pack|
+          module_name = pack.name.camelize
+          Object.const_set(module_name, Module.new) if pack.config.automatic_pack_namespace? #
           Stimpack.config.paths.each do |path|
-            @app.paths[path] << pack.path.join(path)
+            @app.paths[path] << pack.path.join(path) unless pack.config.automatic_pack_namespace?
+            ::Rails.autoloaders.main.push_dir(pack.path.join(path), namespace: module_name.constantize) if pack.config.automatic_pack_namespace? && Dir.exist?(pack.path.join(path))
           end
         end
       end

--- a/lib/stimpack/integrations/rails.rb
+++ b/lib/stimpack/integrations/rails.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/inflections"
-require 'pry'
 
 module Stimpack
   module Integrations

--- a/lib/stimpack/integrations/rails.rb
+++ b/lib/stimpack/integrations/rails.rb
@@ -8,7 +8,6 @@ module Stimpack
     class Rails
       def initialize(app)
         @app = app
-        ::Rails.autoloaders.main.log!
         Stimpack.config.paths.freeze
         create_engines
         inject_paths

--- a/lib/stimpack/pack/configuration.rb
+++ b/lib/stimpack/pack/configuration.rb
@@ -16,6 +16,11 @@ module Stimpack
       end
       alias_method :engine?, :engine
 
+      def automatic_pack_namespace
+        data.fetch("automatic_pack_namespace", false)
+      end
+      alias_method :automatic_pack_namespace?, :automatic_pack_namespace
+
       private
 
       def data

--- a/spec/fixtures/rails-7.0/packs/jackets/app/models/winter.rb
+++ b/spec/fixtures/rails-7.0/packs/jackets/app/models/winter.rb
@@ -1,0 +1,5 @@
+module Jackets
+  class Winter < ApplicationRecord
+
+  end
+end

--- a/spec/fixtures/rails-7.0/packs/jackets/app/public/jackets.rb
+++ b/spec/fixtures/rails-7.0/packs/jackets/app/public/jackets.rb
@@ -1,0 +1,1 @@
+module Jackets; end

--- a/spec/fixtures/rails-7.0/packs/jackets/app/public/jackets.rb
+++ b/spec/fixtures/rails-7.0/packs/jackets/app/public/jackets.rb
@@ -1,1 +1,5 @@
-module Jackets; end
+module Jackets
+  def test_operation
+    "test result"
+  end
+end

--- a/spec/fixtures/rails-7.0/packs/jackets/app/public/summer.rb
+++ b/spec/fixtures/rails-7.0/packs/jackets/app/public/summer.rb
@@ -1,0 +1,4 @@
+module Jackets
+ class Summer < ApplicationRecord
+ end
+end

--- a/spec/fixtures/rails-7.0/packs/jackets/package.yml
+++ b/spec/fixtures/rails-7.0/packs/jackets/package.yml
@@ -1,0 +1,2 @@
+metadata:
+  automatic_pack_namespace: true

--- a/spec/stimpack_spec.rb
+++ b/spec/stimpack_spec.rb
@@ -34,4 +34,10 @@ RSpec.describe Stimpack do
       expect(defined?(Shorts::Engine)).to eq("constant")
     end
   end
+
+  context 'packs with automatic namespaces' do
+    it 'can find namespaced models without namespace dirs' do
+      expect(defined?(Jackets::Winter)).to eq("constant")
+    end
+  end
 end

--- a/spec/stimpack_spec.rb
+++ b/spec/stimpack_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Stimpack do
   context 'packs with automatic namespaces' do
     it 'can find namespaced models without namespace dirs' do
       expect(defined?(Jackets::Winter)).to eq("constant")
+      expect(defined?(Jackets::Summer)).to eq("constant")
     end
   end
 end

--- a/spec/stimpack_spec.rb
+++ b/spec/stimpack_spec.rb
@@ -40,5 +40,13 @@ RSpec.describe Stimpack do
       expect(defined?(Jackets::Winter)).to eq("constant")
       expect(defined?(Jackets::Summer)).to eq("constant")
     end
+
+    xit 'can access methods on the root namespace' do
+      # left as a skipped test to reveal the intention that
+      #    a) we want this behavior
+      #    b) we recognize this behavior is not working at this time
+      #    c) we felt the overall feature has value apart from root namespace methods
+      expect(Jackets.test_operation).to eq("test result")
+    end
   end
 end


### PR DESCRIPTION
Stimpack already configures the load paths for packs. However, when a single namespace is intended for the entire pack, 
Zeitwerk requires an extra subdirectory within each source code path (models, controllers, etc) in order for the classes to be
located correctly with a namespace. This can prove burdensome with lots of needless and extra copies of your namespace:

```
products
├── app
│   ├── models
│   │   └── products
│   │       ├── package_record.rb
│   │       ├── product.rb  <-- Products::Product
│   │       └── sku.rb  <-- Products::SKU
│   ├── public
│   │   ├── products
│   │   │   ├── product_mediums.rb
│   │   │   └── products_operations.rb
│   │   └── products.rb
│   └── services
│       └── products
```

Instead, we'd like to support this:


```
products
├── app
│   ├── models
│   │     ├── package_record.rb 
│   │     ├── product.rb. <-- Products::Product
│   │     └── sku.rb <-- Products::SKU
│   ├── public
│   │   │   ├── product_mediums.rb
│   │   │   └── products_operations.rb
│   │   └── products.rb
│   └── services
```