### PR TITLE
Add Spring integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ metadata:
 
 ## Ecosystem and Integrations
 
+### Spring application preloader
+
+For Spring to pick up new packs, add a watch on the packs folder:
+
+```ruby
+# config/spring.rb
+
+# Keep in sync with `Stimpack.config.root`
+Spring.watch("packs")
+```
+
 ### RSpec Integration
 Simply add `--require stimpack/rspec` to your `.rspec`.
 Or, if you'd like, pass it as an argument to `rspec`:


### PR DESCRIPTION
By default, Spring does not watch and react to changes in packs folder, leading to inconsistent state.