### PR TITLE
Allow packs configuration to be set in one place

### DIFF
--- a/lib/stimpack.rb
+++ b/lib/stimpack.rb
@@ -18,6 +18,23 @@ module Stimpack
     def root
       @root ||= Rails::Application.find_root(Dir.pwd)
     end
+
+    #
+    # This is temporary. For now, we allow Stimpack roots to be configured via Stimpack.config.root
+    # Later, if clients configure packs directly, we can deprecate the Stimpack setting and
+    # remove this function and its invocations.
+    #
+    def configure_packs
+      Packs.configure do |config|
+        roots = Array(Stimpack.config.root)
+        pack_paths = roots.flat_map do |root|
+          # Support nested packs by default. Later, this can be pushed to a client configuration.
+          ["#{root}/*", "#{root}/*/*"]
+        end
+
+        config.pack_paths = pack_paths
+      end
+    end
   end
 
   @config = ActiveSupport::OrderedOptions.new

--- a/lib/stimpack/integrations/factory_bot.rb
+++ b/lib/stimpack/integrations/factory_bot.rb
@@ -8,6 +8,7 @@ module Stimpack
         Stimpack.configure_packs
 
         Packs.all.each do |pack|
+          next if pack.relative_path.glob('*.gemspec').any?
           app.config.factory_bot.definition_file_paths << pack.relative_path.join("spec/factories").to_s
         end
       end

--- a/lib/stimpack/integrations/factory_bot.rb
+++ b/lib/stimpack/integrations/factory_bot.rb
@@ -5,6 +5,7 @@ module Stimpack
     class FactoryBot
       def initialize(app)
         return unless app.config.respond_to?(:factory_bot)
+        Stimpack.configure_packs
 
         Packs.all.each do |pack|
           app.config.factory_bot.definition_file_paths << pack.relative_path.join("spec/factories").to_s

--- a/lib/stimpack/integrations/rails.rb
+++ b/lib/stimpack/integrations/rails.rb
@@ -10,15 +10,13 @@ module Stimpack
         @app = app
 
         Stimpack.config.paths.freeze
+        Stimpack.configure_packs
+
         create_engines
         inject_paths
       end
 
       def create_engines
-        # Ideally, the user just does `Packs.configure { |config| config.roots = '...' }`
-        # But that would be a public API change and can come later
-        Packs.configure { |config| config.roots = Array(Stimpack.config.root) }
-
         Packs.all.each do |pack|
           next unless pack.metadata['engine']
 

--- a/lib/stimpack/integrations/rspec.rb
+++ b/lib/stimpack/integrations/rspec.rb
@@ -10,11 +10,12 @@ module Stimpack
         to_run = ::RSpec.configuration.instance_variable_get(:@files_or_directories_to_run)
         default_path = ::RSpec.configuration.default_path
 
+        Stimpack.configure_packs
+
         if to_run == [default_path]
           # This is the default case when you run `rspec`. We want to add all the pack's spec paths
           # to the collection of directories to run.
 
-          Packs.configure { |config| config.roots = Array(Stimpack.config.root) }
           pack_paths = Packs.all.map do |pack|
             spec_path = pack.relative_path.join(default_path)
             spec_path.to_s if spec_path.exist?

--- a/lib/stimpack/version.rb
+++ b/lib/stimpack/version.rb
@@ -1,3 +1,3 @@
 module Stimpack
-  VERSION = "0.8.1".freeze
+  VERSION = "0.8.2".freeze
 end

--- a/sorbet/rbi/gems/packs@0.0.4.rbi
+++ b/sorbet/rbi/gems/packs@0.0.4.rbi
@@ -12,10 +12,10 @@ module Packs
     sig { void }
     def bust_cache!; end
 
-    sig { returns(::Packs::Configuration) }
+    sig { returns(::Packs::Private::Configuration) }
     def config; end
 
-    sig { params(blk: T.proc.params(arg0: ::Packs::Configuration).void).void }
+    sig { params(blk: T.proc.params(arg0: ::Packs::Private::Configuration).void).void }
     def configure(&blk); end
 
     sig { params(name: ::String).returns(T.nilable(::Packs::Pack)) }
@@ -32,17 +32,6 @@ module Packs
     sig { returns(T::Hash[::String, ::Packs::Pack]) }
     def packs_by_name; end
   end
-end
-
-class Packs::Configuration
-  sig { void }
-  def initialize; end
-
-  sig { returns(T::Array[::Pathname]) }
-  def roots; end
-
-  sig { params(roots: T::Array[::String]).void }
-  def roots=(roots); end
 end
 
 Packs::PACKAGE_FILE = T.let(T.unsafe(nil), String)
@@ -77,4 +66,19 @@ module Packs::Private
   end
 end
 
-Packs::ROOTS = T.let(T.unsafe(nil), Array)
+class Packs::Private::Configuration < ::T::Struct
+  prop :pack_paths, T::Array[::String]
+
+  class << self
+    sig { returns(::Packs::Private::Configuration) }
+    def fetch; end
+
+    def inherited(s); end
+
+    sig { params(config_hash: T::Hash[T.untyped, T.untyped]).returns(T::Array[::String]) }
+    def pack_paths(config_hash); end
+  end
+end
+
+Packs::Private::Configuration::CONFIGURATION_PATHNAME = T.let(T.unsafe(nil), Pathname)
+Packs::Private::Configuration::DEFAULT_PACK_PATHS = T.let(T.unsafe(nil), Array)


### PR DESCRIPTION
This PR bumps `packs`, which allows:
- `Stimpack` to configure `packs` directly
- `packs.yml` to take precedence for `packs` configuration if the user is using it, making `stimpack`'s configuration of `packs` a no-op.